### PR TITLE
Update name of package set updater script

### DIFF
--- a/.github/workflows/importer.yml
+++ b/.github/workflows/importer.yml
@@ -68,4 +68,4 @@ jobs:
         run: cd ci && nix develop --command 'registry-importer' 'update'
 
       - name: Import new versions to the package sets
-        run: cd ci && nix develop --command 'registry-package-set' 'commit'
+        run: cd ci && nix develop --command 'registry-package-set-updater' 'commit'


### PR DESCRIPTION
This updates the name of the registry package set updater script, to go along with https://github.com/purescript/registry/pull/469. They should be merged together.